### PR TITLE
fix: apk render problem

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -11,3 +11,6 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+
+# local properties
+local.properties

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.smartband">
+    <uses-permission android:name="android.permission.INTERNET"/>
    <application
         android:label="smartband"
         android:name="${applicationName}"

--- a/lib/src/routes/routes.dart
+++ b/lib/src/routes/routes.dart
@@ -1,4 +1,4 @@
-import 'dart:js';
+// import 'dart:js';
 
 import 'package:flutter/material.dart';
 import 'package:smartband/src/pages/home_page.dart';


### PR DESCRIPTION
Haciendo prueba de compilaciòn se detecto que el apk no podia acceder a los servicios de internet puesto que el manifest no incluia esos permisos. Previo a esto, la importaciòn de dart js en routes hacia conflicto con la compilacion del apk